### PR TITLE
CastCore framework without raw representable

### DIFF
--- a/cast-script/Cast.swift
+++ b/cast-script/Cast.swift
@@ -75,27 +75,6 @@ public extension JSONDictionary {
         }
         return nil
     }
-
-    public func value<A: RawRepresentable>(for key: JSONKey) -> A? where A.RawValue: JSONValue  {
-        if let raw: A.RawValue = value(for: key)  {
-            return A(rawValue: raw)
-        }
-        return nil
-    }
-
-    public func value<A: RawRepresentable>(for key: JSONKey) -> [A]? where A.RawValue: JSONValue {
-        if let rawArray: [A.RawValue] = value(for: key)  {
-            return rawArray.flatMap { A(rawValue: $0) }
-        }
-        return nil
-    }
-
-}
-
-extension RawRepresentable  {
-    public var jsonValue: Any? {
-        return self.rawValue
-    }
 }
 
 extension Dictionary: JSONDictionary, JSONValue {
@@ -229,12 +208,6 @@ extension Array where Element: JSONValue {
         }
         return nil
     }
-    public var jsonValue: Any? {
-        return self.map { $0.jsonValue }
-    }
-}
-
-extension Array where Element: RawRepresentable, Element.RawValue: JSONValue {
     public var jsonValue: Any? {
         return self.map { $0.jsonValue }
     }

--- a/cast-script/CastCore.h
+++ b/cast-script/CastCore.h
@@ -1,0 +1,19 @@
+//
+//  CastCore.h
+//  CastCore
+//
+//  Created by Guy on 21/05/2016.
+//  Copyright © 2016 Houzz. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for Cast.
+FOUNDATION_EXPORT double CastVersionNumber;
+
+//! Project version string for Cast.
+FOUNDATION_EXPORT const unsigned char CastVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Cast/PublicHeader.h>
+
+

--- a/cast-script/CastRaw.swift
+++ b/cast-script/CastRaw.swift
@@ -1,0 +1,36 @@
+//
+//  CastRaw.swift
+//
+//  Created by Guy on 28/10/2016.
+//  Copyright © 2016 Houzz. All rights reserved.
+//
+
+import Foundation
+
+extension JSONDictionary {
+    public func value<A: RawRepresentable>(for key: JSONKey) -> A? where A.RawValue: JSONValue  {
+        if let raw: A.RawValue = value(for: key)  {
+            return A(rawValue: raw)
+        }
+        return nil
+    }
+
+    public func value<A: RawRepresentable>(for key: JSONKey) -> [A]? where A.RawValue: JSONValue {
+        if let rawArray: [A.RawValue] = value(for: key)  {
+            return rawArray.flatMap { A(rawValue: $0) }
+        }
+        return nil
+    }
+}
+
+extension RawRepresentable  {
+    public var jsonValue: Any? {
+        return self.rawValue
+    }
+}
+
+extension Array where Element: RawRepresentable, Element.RawValue: JSONValue {
+    public var jsonValue: Any? {
+        return self.map { $0.jsonValue }
+    }
+}

--- a/cast.xcodeproj/project.pbxproj
+++ b/cast.xcodeproj/project.pbxproj
@@ -7,9 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D87AEE641E01E17700C6C300 /* CastRaw.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87AEE631E01E17700C6C300 /* CastRaw.swift */; };
+		D87AEE661E01E18F00C6C300 /* CastRaw.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87AEE631E01E17700C6C300 /* CastRaw.swift */; };
+		D87AEE671E01E19000C6C300 /* CastRaw.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87AEE631E01E17700C6C300 /* CastRaw.swift */; };
+		D87AEE891E01F3A100C6C300 /* Cast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E405FEE81DD8B8AB00496CCE /* Cast.swift */; };
+		D87AEE8F1E01F70E00C6C300 /* CastCore.h in Headers */ = {isa = PBXBuildFile; fileRef = D87AEE7B1E01ECC200C6C300 /* CastCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D87AEE901E01F84800C6C300 /* CastRaw.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87AEE631E01E17700C6C300 /* CastRaw.swift */; };
+		D87AEE911E01F85100C6C300 /* Cast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E405FEE81DD8B8AB00496CCE /* Cast.swift */; };
+		D87AEE921E01F8B400C6C300 /* Cast.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46F92621CF07BBB00BFE4AF /* Cast.framework */; };
+		D87AEE931E01F8B400C6C300 /* Cast.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E46F92621CF07BBB00BFE4AF /* Cast.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E405FEEA1DD8B9E800496CCE /* Cast.h in Headers */ = {isa = PBXBuildFile; fileRef = E405FEE71DD8B8AB00496CCE /* Cast.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E405FEEB1DD8B9EE00496CCE /* Cast.h in Headers */ = {isa = PBXBuildFile; fileRef = E405FEE71DD8B8AB00496CCE /* Cast.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E405FEEC1DD8BA5A00496CCE /* Cast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E405FEE81DD8B8AB00496CCE /* Cast.swift */; };
 		E405FEED1DD8BA5B00496CCE /* Cast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E405FEE81DD8B8AB00496CCE /* Cast.swift */; };
 		E405FEEE1DD8BA5C00496CCE /* Cast.swift in Sources */ = {isa = PBXBuildFile; fileRef = E405FEE81DD8B8AB00496CCE /* Cast.swift */; };
 		E46F92441CF04F6B00BFE4AF /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46F92431CF04F6B00BFE4AF /* main.swift */; };
@@ -19,8 +27,6 @@
 		E46F92A01CF0802F00BFE4AF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E46F929F1CF0802F00BFE4AF /* Assets.xcassets */; };
 		E46F92A31CF0802F00BFE4AF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E46F92A11CF0802F00BFE4AF /* LaunchScreen.storyboard */; };
 		E46F92AE1CF0802F00BFE4AF /* CastingAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46F92AD1CF0802F00BFE4AF /* CastingAppTests.swift */; };
-		E46F92BA1CF081C200BFE4AF /* Cast.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46F92621CF07BBB00BFE4AF /* Cast.framework */; };
-		E46F92BB1CF081C200BFE4AF /* Cast.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E46F92621CF07BBB00BFE4AF /* Cast.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E4A03A4F1CF08B65007FD77B /* Classy.cast in Sources */ = {isa = PBXBuildFile; fileRef = E46F92B61CF0805900BFE4AF /* Classy.cast */; };
 		E4A509AB1CF0A468007DA42E /* Cast.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46F92621CF07BBB00BFE4AF /* Cast.framework */; };
 /* End PBXBuildFile section */
@@ -40,19 +46,19 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
+		D87AEE941E01F8B400C6C300 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E46F92381CF04F6B00BFE4AF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E46F92611CF07BBB00BFE4AF;
+			remoteInfo = "Cast iOS";
+		};
 		E46F92AA1CF0802F00BFE4AF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E46F92381CF04F6B00BFE4AF /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = E46F92951CF0802F00BFE4AF;
 			remoteInfo = CastingApp;
-		};
-		E46F92BC1CF081C200BFE4AF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = E46F92381CF04F6B00BFE4AF /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E46F92611CF07BBB00BFE4AF;
-			remoteInfo = "Cast iOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -72,7 +78,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				E46F92BB1CF081C200BFE4AF /* Cast.framework in Embed Frameworks */,
+				D87AEE931E01F8B400C6C300 /* Cast.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -80,6 +86,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		D87AEE601E01E0CA00C6C300 /* CastCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CastCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D87AEE631E01E17700C6C300 /* CastRaw.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CastRaw.swift; sourceTree = "<group>"; };
+		D87AEE7B1E01ECC200C6C300 /* CastCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CastCore.h; sourceTree = "<group>"; };
 		E405FEE71DD8B8AB00496CCE /* Cast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Cast.h; sourceTree = "<group>"; };
 		E405FEE81DD8B8AB00496CCE /* Cast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cast.swift; sourceTree = "<group>"; };
 		E46F92401CF04F6B00BFE4AF /* cast */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cast; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -102,6 +111,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		D87AEE581E01E0CA00C6C300 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E46F923D1CF04F6B00BFE4AF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -127,7 +143,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E46F92BA1CF081C200BFE4AF /* Cast.framework in Frameworks */,
+				D87AEE921E01F8B400C6C300 /* Cast.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -169,6 +185,7 @@
 				E46F92961CF0802F00BFE4AF /* CastingApp.app */,
 				E46F92A91CF0802F00BFE4AF /* CastingAppTests.xctest */,
 				E4A509B61CF0A496007DA42E /* CastTV.framework */,
+				D87AEE601E01E0CA00C6C300 /* CastCore.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -185,7 +202,9 @@
 			isa = PBXGroup;
 			children = (
 				E405FEE71DD8B8AB00496CCE /* Cast.h */,
+				D87AEE7B1E01ECC200C6C300 /* CastCore.h */,
 				E405FEE81DD8B8AB00496CCE /* Cast.swift */,
+				D87AEE631E01E17700C6C300 /* CastRaw.swift */,
 				E46F92661CF07BBB00BFE4AF /* Info.plist */,
 			);
 			name = Cast;
@@ -218,6 +237,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		D87AEE591E01E0CA00C6C300 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D87AEE8F1E01F70E00C6C300 /* CastCore.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E46F925F1CF07BBB00BFE4AF /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -237,6 +264,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		D87AEE551E01E0CA00C6C300 /* CastCore iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D87AEE5C1E01E0CA00C6C300 /* Build configuration list for PBXNativeTarget "CastCore iOS" */;
+			buildPhases = (
+				D87AEE561E01E0CA00C6C300 /* Sources */,
+				D87AEE581E01E0CA00C6C300 /* Frameworks */,
+				D87AEE591E01E0CA00C6C300 /* Headers */,
+				D87AEE5B1E01E0CA00C6C300 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "CastCore iOS";
+			productName = Cast;
+			productReference = D87AEE601E01E0CA00C6C300 /* CastCore.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		E46F923F1CF04F6B00BFE4AF /* cast */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E46F92471CF04F6B00BFE4AF /* Build configuration list for PBXNativeTarget "cast" */;
@@ -302,7 +347,7 @@
 				E46F92B81CF080C700BFE4AF /* PBXBuildRule */,
 			);
 			dependencies = (
-				E46F92BD1CF081C200BFE4AF /* PBXTargetDependency */,
+				D87AEE951E01F8B400C6C300 /* PBXTargetDependency */,
 			);
 			name = CastingApp;
 			productName = CastingApp;
@@ -391,6 +436,7 @@
 				E46F92611CF07BBB00BFE4AF /* Cast iOS */,
 				E46F926A1CF07BCA00BFE4AF /* Cast OSX */,
 				E4A509AC1CF0A496007DA42E /* Cast tvOS */,
+				D87AEE551E01E0CA00C6C300 /* CastCore iOS */,
 				E46F92951CF0802F00BFE4AF /* CastingApp */,
 				E46F92A81CF0802F00BFE4AF /* CastingAppTests */,
 			);
@@ -398,6 +444,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		D87AEE5B1E01E0CA00C6C300 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E46F92601CF07BBB00BFE4AF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -439,11 +492,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		D87AEE561E01E0CA00C6C300 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D87AEE911E01F85100C6C300 /* Cast.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E46F923C1CF04F6B00BFE4AF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				E46F92441CF04F6B00BFE4AF /* main.swift in Sources */,
+				D87AEE641E01E17700C6C300 /* CastRaw.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -451,7 +513,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E405FEEC1DD8BA5A00496CCE /* Cast.swift in Sources */,
+				D87AEE891E01F3A100C6C300 /* Cast.swift in Sources */,
+				D87AEE901E01F84800C6C300 /* CastRaw.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -459,6 +522,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D87AEE661E01E18F00C6C300 /* CastRaw.swift in Sources */,
 				E405FEED1DD8BA5B00496CCE /* Cast.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -485,6 +549,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D87AEE671E01E19000C6C300 /* CastRaw.swift in Sources */,
 				E405FEEE1DD8BA5C00496CCE /* Cast.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -492,15 +557,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		D87AEE951E01F8B400C6C300 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E46F92611CF07BBB00BFE4AF /* Cast iOS */;
+			targetProxy = D87AEE941E01F8B400C6C300 /* PBXContainerItemProxy */;
+		};
 		E46F92AB1CF0802F00BFE4AF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = E46F92951CF0802F00BFE4AF /* CastingApp */;
 			targetProxy = E46F92AA1CF0802F00BFE4AF /* PBXContainerItemProxy */;
-		};
-		E46F92BD1CF081C200BFE4AF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = E46F92611CF07BBB00BFE4AF /* Cast iOS */;
-			targetProxy = E46F92BC1CF081C200BFE4AF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -524,6 +589,97 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		D87AEE5D1E01E0CA00C6C300 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				EXPANDED_CODE_SIGN_IDENTITY = "";
+				INFOPLIST_FILE = "cast-script/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.houzz.CastCore;
+				PRODUCT_NAME = CastCore;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		D87AEE5E1E01E0CA00C6C300 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				EXPANDED_CODE_SIGN_IDENTITY = "";
+				INFOPLIST_FILE = "cast-script/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.houzz.CastCore;
+				PRODUCT_NAME = CastCore;
+				PROVISIONING_PROFILE = "0eb6405e-d817-4762-a524-0e6a2de5cfd7";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		D87AEE5F1E01E0CA00C6C300 /* Distribution Ad Hoc */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "cast-script/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.houzz.CastCore;
+				PRODUCT_NAME = CastCore;
+				PROVISIONING_PROFILE = "7642293e-12b0-4cd3-81f5-0d8f60a47de5";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = "Distribution Ad Hoc";
+		};
 		E43CEC8A1CF9FB2F00811415 /* Distribution Ad Hoc */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1032,6 +1188,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		D87AEE5C1E01E0CA00C6C300 /* Build configuration list for PBXNativeTarget "CastCore iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D87AEE5D1E01E0CA00C6C300 /* Debug */,
+				D87AEE5E1E01E0CA00C6C300 /* Release */,
+				D87AEE5F1E01E0CA00C6C300 /* Distribution Ad Hoc */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		E46F923B1CF04F6B00BFE4AF /* Build configuration list for PBXProject "cast" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/cast.xcodeproj/xcshareddata/xcschemes/CastCore iOS.xcscheme
+++ b/cast.xcodeproj/xcshareddata/xcschemes/CastCore iOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0810"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D87AEE551E01E0CA00C6C300"
+               BuildableName = "CastCore.framework"
+               BlueprintName = "CastCore iOS"
+               ReferencedContainer = "container:cast.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D87AEE551E01E0CA00C6C300"
+            BuildableName = "CastCore.framework"
+            BlueprintName = "CastCore iOS"
+            ReferencedContainer = "container:cast.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D87AEE551E01E0CA00C6C300"
+            BuildableName = "CastCore.framework"
+            BlueprintName = "CastCore iOS"
+            ReferencedContainer = "container:cast.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
In our application we have a number of `NS_ENUM` and `NS_OPTION` types
that we would like to embed in `DictionaryConvertible` types. The
built-in support to serialize these in json as their raw representable
value (usually an integer) is not what we want. But since Cast's
prinicipal serialization methods are overloaded to use raw value
converters, our types can not be extended to DictionaryConvertible for a
custom representation.

To avoid bringing these extensions into scope, I moved them into a
separate `ClassRaw.swift` source and created a new framework target
`CastCore` which doesn't include them. The original `Cast` framework
works as before. Since I don't know if this is useful to others, I
haven't created osx or tv variants of the stripped down framework.